### PR TITLE
Changes to make HTTPS work

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ $ cd <root of this repo>
 $ ansible-playbook scripts/provision-server.yml -i scripts/hosts --extra-vars "@scripts/variables.yml"
 ```
 
+If you have set `use_ssl` to `true` in your variables, you will need to install a PEM certificate file and key at `/etc/nginx/od-import.crt` and `/etc/nginx/od-import.key` respectively.
+
 
 # Known Issues
 1. Webpacker compilation fails with no explanation on Linode: this is probably due to lack of memory for the compilation - stop one of the other sites to resolve this.

--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -30,7 +30,7 @@ export default class App extends Component {
         <div>
           <Navigation data={this.props}/>
           <SiteInfo config={this.props.config}/>
-          <ActionCableProvider url={`ws://${window.location.host}/${sitekey}/cable`}>
+          <ActionCableProvider url={`${ws_protocol}${window.location.host}/${sitekey}/cable`}>
             <Container fluid={true}>
               <Row>
                 <Router>

--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -9,6 +9,7 @@ import { ActionCableProvider } from 'react-actioncable-provider';
 import Navigation from "./navigation/Navigation";
 import SiteInfo from "./SiteInfo";
 import { sitekey } from "../config";
+import { ws_protocol } from "../config";
 import AuthorsPage from "./pages/AuthorsPage";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";

--- a/app/javascript/config.js
+++ b/app/javascript/config.js
@@ -1,2 +1,3 @@
 export const sitekey = 'opendoorstempsite';
 export const authors_path = (letter) => `/${sitekey}/authors${ letter ? `?letter=${letter}` :""}`;
+export const ws_protocol = 'ws://';

--- a/scripts/ansible/templates/config.js.j2
+++ b/scripts/ansible/templates/config.js.j2
@@ -3,5 +3,5 @@ export const authors_path = (letter) => `/${sitekey}/authors${ letter ? `?letter
 {% if use_ssl %}
 export const ws_protocol = 'wss://';
 {% else %}
-export const ws_protocol = 'wss://';
+export const ws_protocol = 'ws://';
 {% endif %}

--- a/scripts/ansible/templates/config.js.j2
+++ b/scripts/ansible/templates/config.js.j2
@@ -1,2 +1,7 @@
 export const sitekey = "{{ sitekey }}";
 export const authors_path = (letter) => `/${sitekey}/authors${ letter ? `?letter=${letter}` :""}`;
+{% if use_ssl %}
+export const ws_protocol = 'wss://';
+{% else %}
+export const ws_protocol = 'wss://';
+{% endif %}

--- a/scripts/provision/nginx/sites-available/opendoors-sites.j2
+++ b/scripts/provision/nginx/sites-available/opendoors-sites.j2
@@ -4,6 +4,13 @@ map $http_upgrade $connection_upgrade {
 }
 
 server {
+
+  {% if use_ssl %}
+  listen 443 ssl http2;
+  ssl_certificate /etc/nginx/od-import.crt;
+  ssl_certificate_key /etc/nginx/od-import.key;
+  {% endif %}
+
   root /var/www;
 
   # Make site accessible from http://localhost/

--- a/scripts/variables.yml.example
+++ b/scripts/variables.yml.example
@@ -21,3 +21,5 @@ remote_hostname: << hostname for the remote server (added to hosts file) >>
 remote_pw: << not used - just convenient for reference >>
 remote_pw_hash: << hash of user password >>
 local_ssh_path: << path to the public key to add to authorised keys on the server >>
+
+use_ssl: << false / true, note that if true, you will need to install a cert/key for nginx yourself! See the README. >>


### PR DESCRIPTION
Adds a use_ssl variable for Ansible, which is then used to determine whether to include the relevant sections in the nginx config, and the frontend config.

I did not include any relevant ansible to install key/cert files when use_ssl is true, for a couple reasons:
1. Providing a default self-signed key/cert would result in a production key/cert being overwritten without changes.
2. key/certs don't fit nicely into a variable so going that route didn't seem very nice
3. The provision-server ansible script starts nginx before installing the configuration, so them not being there on the provisioning shouldn't matter as long as the files are installed afterwards and before deploying sites.