### PR TITLE
OD-1724 Remove Chapters.AuthorID from Rails Schema

### DIFF
--- a/db/migrate/20231021222726_remove_author_id_from_chapters.rb
+++ b/db/migrate/20231021222726_remove_author_id_from_chapters.rb
@@ -1,0 +1,5 @@
+class RemoveAuthorIdFromChapters < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :chapters, :authorID, :integer
+  end
+end

--- a/db/migrate/20231022170248_update_encoding_to_utf8_mb4.rb
+++ b/db/migrate/20231022170248_update_encoding_to_utf8_mb4.rb
@@ -1,0 +1,8 @@
+class UpdateEncodingToUtf8Mb4 < ActiveRecord::Migration[5.2]
+  def change
+    execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    ActiveRecord::Base.connection.tables.each do |table|
+      execute "ALTER TABLE `#{table}` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_21_222726) do
+ActiveRecord::Schema.define(version: 2023_10_22_170248) do
 
-  create_table "archive_configs", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "archive_configs", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", limit: 45, null: false
     t.string "name"
     t.string "fandom"
-    t.text "stories_note"
-    t.text "bookmarks_note"
+    t.text "stories_note", limit: 16777215
+    t.text "bookmarks_note", limit: 16777215
     t.boolean "send_email", default: false, null: false
     t.boolean "post_preview", default: false, null: false
     t.string "archivist", limit: 100, default: "testy", null: false
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2023_10_21_222726) do
     t.index ["key"], name: "Key_UNIQUE", unique: true
   end
 
-  create_table "audits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "audits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
     t.integer "associated_id"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2023_10_21_222726) do
     t.string "user_type"
     t.string "username"
     t.string "action"
-    t.text "audited_changes"
+    t.text "audited_changes", limit: 16777215
     t.integer "version", default: 0
     t.string "comment", limit: 2048
     t.string "remote_address"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2023_10_21_222726) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table "authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
     t.boolean "imported", default: false, null: false
@@ -58,22 +58,22 @@ ActiveRecord::Schema.define(version: 2023_10_21_222726) do
     t.index ["id"], name: "id_UNIQUE", unique: true
   end
 
-  create_table "chapters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "chapters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "position"
     t.string "title", default: "", null: false
-    t.text "text", limit: 16777215
+    t.text "text", limit: 4294967295
     t.datetime "date"
     t.integer "story_id", default: 0
-    t.text "notes"
+    t.text "notes", limit: 16777215
     t.string "url", limit: 1024
     t.index ["id"], name: "id_UNIQUE", unique: true
     t.index ["story_id"], name: "storyid"
   end
 
-  create_table "stories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "stories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.text "summary"
-    t.text "notes"
+    t.text "summary", limit: 16777215
+    t.text "notes", limit: 16777215
     t.integer "author_id", default: 0
     t.string "rating", default: "", null: false
     t.datetime "date"
@@ -95,10 +95,10 @@ ActiveRecord::Schema.define(version: 2023_10_21_222726) do
     t.index ["id"], name: "id_UNIQUE", unique: true
   end
 
-  create_table "story_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "story_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.text "summary"
-    t.text "notes"
+    t.text "summary", limit: 16777215
+    t.text "notes", limit: 16777215
     t.integer "author_id", default: 0
     t.string "rating", default: "", null: false
     t.datetime "date"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 2023_10_21_222726) do
     t.index ["id"], name: "id_UNIQUE", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.string "password_digest"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2023_10_21_222726) do
 
-  create_table "archive_configs", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "archive_configs", id: :integer, options: "ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.string "key", limit: 45, null: false
     t.string "name"
     t.string "fandom"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["key"], name: "Key_UNIQUE", unique: true
   end
 
-  create_table "audits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "audits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
     t.integer "associated_id"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table "authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
     t.boolean "imported", default: false, null: false
@@ -58,10 +58,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["id"], name: "id_UNIQUE", unique: true
   end
 
-  create_table "chapters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "chapters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "position"
     t.string "title", default: "", null: false
-    t.integer "authorID", default: 0, null: false
     t.text "text", limit: 16777215
     t.datetime "date"
     t.integer "story_id", default: 0
@@ -71,7 +70,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["story_id"], name: "storyid"
   end
 
-  create_table "stories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "stories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.text "summary"
     t.text "notes"
@@ -96,7 +95,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["id"], name: "id_UNIQUE", unique: true
   end
 
-  create_table "story_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "story_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.text "summary"
     t.text "notes"
@@ -121,7 +120,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["id"], name: "id_UNIQUE", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.string "password_digest"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -93,7 +93,6 @@ CREATE TABLE `chapters` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `position` bigint(22) DEFAULT NULL,
   `title` varchar(255) NOT NULL DEFAULT '',
-  `authorID` int(11) NOT NULL DEFAULT '0',
   `text` mediumtext,
   `date` datetime DEFAULT NULL,
   `story_id` int(11) DEFAULT '0',

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -12,19 +12,19 @@
 
 DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ar_internal_metadata` (
   `key` varchar(255) NOT NULL,
   `value` varchar(255) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `archive_configs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `archive_configs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `key` varchar(45) NOT NULL,
@@ -40,12 +40,12 @@ CREATE TABLE `archive_configs` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`),
   UNIQUE KEY `Key_UNIQUE` (`key`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `audits`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `audits` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `auditable_id` int(11) DEFAULT NULL,
@@ -68,12 +68,12 @@ CREATE TABLE `audits` (
   KEY `user_index` (`user_id`,`user_type`),
   KEY `index_audits_on_request_uuid` (`request_uuid`),
   KEY `index_audits_on_created_at` (`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `authors`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `authors` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
@@ -83,12 +83,12 @@ CREATE TABLE `authors` (
   `to_delete` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=51 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=51 DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `chapters`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `chapters` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `position` bigint(22) DEFAULT NULL,
@@ -101,21 +101,21 @@ CREATE TABLE `chapters` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`),
   KEY `storyid` (`story_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) NOT NULL,
   PRIMARY KEY (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `stories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `stories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL DEFAULT '',
@@ -141,12 +141,12 @@ CREATE TABLE `stories` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`),
   KEY `authorId` (`author_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=55 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=55 DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `story_links`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `story_links` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) CHARACTER SET latin1 NOT NULL DEFAULT '',
@@ -172,12 +172,12 @@ CREATE TABLE `story_links` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`),
   KEY `authorId` (`author_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE `users` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/scripts/docker/cable.yml
+++ b/scripts/docker/cable.yml
@@ -2,8 +2,10 @@ local: &local
   adapter: redis
   url: redis://localhost:6379
 
-production: *local
-development:
+docker: &docker
   adapter: redis
   url: redis://redis:6379
-test: *local
+
+production: *local
+development: *docker
+test: *docker


### PR DESCRIPTION
These changes (except for structure.sql, which was manual) are the result of running the following commands:

```
docker-compose exec web bundle exec rails generate migration RemoveAuthorIDFromChapters authorID:integer
docker-compose run --rm web bundle exec rake db:migrate
```