### PR TITLE
OD-1930 Update Bundle Error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'redis', '~> 4.6'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.17'
 
+# Adding because version 1.17 throws an unsupported rubygems error
+gem "ffi", "< 1.17.0"
+
 group :development do
   # Use Puma as the app server
   gem 'puma', '~> 5.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     globalid (1.0.0)
@@ -332,6 +332,7 @@ DEPENDENCIES
   factory_bot_rails
   faraday (= 1.10.2)
   faraday_middleware (= 1.2.0)
+  ffi (< 1.17.0)
   mysql2 (= 0.5.3)
   net-imap (= 0.3.1)
   puma (~> 5.6)


### PR DESCRIPTION
When I attempted to re-deploy vinxperience using master I ran into the following error:

> TASK [Update bundle] ***************************************************************************************************
> fatal: [172.104.9.186]: FAILED! => {"changed": true, "cmd": ["/usr/share/rvm/gems/ruby-2.7.3/wrappers/bundle", "update"], "delta": "0:00:12.484532", "end": "2024-12-30 02:57:22.234180", "msg": "non-zero return code", "rc": 5, "start": "2024-12-30 02:57:09.749648", "stderr": "", "stderr_lines": [], "stdout": "Fetching gem metadata from https://rubygems.org/...........\nFetching gem metadata from https://rubygems.org/.\nResolving dependencies...............................\nffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is\nincompatible with the current version, 3.1.6", "stdout_lines": ["Fetching gem metadata from https://rubygems.org/...........", "Fetching gem metadata from https://rubygems.org/.", "Resolving dependencies...............................", "ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is", "incompatible with the current version, 3.1.6"]}

I updated the Gemfile to have the ffi gem be a version below 1.17, then ran bundle update ffi, then ran the deployment again using this branch and it was successful.