### PR TITLE
OD-1930 Changed ffi to previous version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'redis', '~> 4.6'
 gem 'bcrypt', '~> 3.1.17'
 
 # Adding because version 1.17 throws an unsupported rubygems error
-gem "ffi", "< 1.17.0"
+gem "ffi", '~> 1.15.5'
 
 group :development do
   # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.16.3)
+    ffi (1.15.5)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     globalid (1.0.0)
@@ -332,7 +332,7 @@ DEPENDENCIES
   factory_bot_rails
   faraday (= 1.10.2)
   faraday_middleware (= 1.2.0)
-  ffi (< 1.17.0)
+  ffi (~> 1.15.5)
   mysql2 (= 0.5.3)
   net-imap (= 0.3.1)
   puma (~> 5.6)

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -2,4 +2,6 @@ class Chapter < ApplicationRecord
   audited comment_required: true
 
   belongs_to :story
+
+  self.primary_key = "id"
 end


### PR DESCRIPTION
The [previous PR](url) which increased the ffi version seemed to work when deploying VinX but failed for another archive. I set the version back to what it was before and that seemed to work.

Also included is a potential fix for the `ActiveRecord::UnknownPrimaryKey (Unknown primary key for table chapters in model Chapter.)` error that sometimes happened, which was previously solved by recreating the indexes on the chapters table. Adding that line to models/chapter.rb fixed the issue on my local docker instance.