### PR TITLE
Added script to switch config files for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ hosts
 # Ignore auto-generated Docker files
 docker-compose.yml
 /scripts/docker/archive_config.sql
+config/cable.yml~
+config/database.yml~
 
 # Ignore compiled assets folder
 /public/opendoorstempsite/assets

--- a/scripts/docker/init.sh
+++ b/scripts/docker/init.sh
@@ -49,7 +49,8 @@ cp scripts/ansible/templates/archive_config.sql.j2 $SQL_FILE
 
 sed -i'' -e 's/{{ sitekey }}/opendoorstempsite/g' $SQL_FILE
 sed -i'' -e 's/{{ name }}/Open Doors Temp Site/g' $SQL_FILE
-sed -i'' -e 's/test/local/g' $SQL_FILE
+sed -i'' -e "s/DEFAULT 'test',/DEFAULT 'local',/g" $SQL_FILE
+sed -i'' -e 's/, "test");/, "local");/g' $SQL_FILE
 
 #Auto-load sample SQL file
 docker-compose exec -T db mysql -h db -uroot -p$MYSQL_PASS opendoorstempsite < $SQL_FILE

--- a/scripts/docker/switch-config-files.sh
+++ b/scripts/docker/switch-config-files.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+# Change directory to root of the repo
+cd "$(dirname "$0")/../.."
+
+for file in 'database.yml' 'cable.yml'
+do
+  file1=$(<"config/$file")
+  file2=$(<"config/$file~")
+  echo "$file1" > "config/$file~"
+  echo "$file2" > "config/$file"
+done


### PR DESCRIPTION
The production temp site and the docker temp site require different versions of database.yml and cable.yml. This means when doing development locally, we need to switch their contents before making any commits. I wrote a script to make it easy to do this.

I also updated the docker init script because previously it was replacing _all_ instances of the word "test" in the sql template with "local", but the word "test" also appears in the default archivist and AO3 collection values. I updated it so it only replaces the word where it's necessary.