### PR TITLE
OD-2137 Numerical Pagination Total Page Number Bug

### DIFF
--- a/app/javascript/components/pagination/NumberPagination.js
+++ b/app/javascript/components/pagination/NumberPagination.js
@@ -36,16 +36,13 @@ export default class NumberPagination extends Component {
     const lastPageIndex = totalPageCount;
 
     if (!shouldShowLeftDots && shouldShowRightDots) {
-      let leftItemCount = 3 + 2 * siblingCount;
-      let leftRange = range(1, leftItemCount);
-
+      let leftRange = range(1, totalPageNumbers);
       return [...leftRange, DOTS, totalPageCount];
     }
 
     if (shouldShowLeftDots && !shouldShowRightDots) {
-      let rightItemCount = 3 + 2 * siblingCount;
       let rightRange = range(
-        totalPageCount - rightItemCount + 1,
+        totalPageCount - totalPageNumbers + 1,
         totalPageCount
       );
       return [firstPageIndex, DOTS, ...rightRange];
@@ -61,7 +58,7 @@ export default class NumberPagination extends Component {
     const currentPageInt = parseInt(this.props.page);
     const totalPagesInt = parseInt(this.props.pages);
     const siblingCount = 3;
-    const totalPageNumbers = siblingCount + 5;
+    const totalPageNumbers = 3 + 2 * siblingCount;
     const paginationRange = this.getPaginationRange(currentPageInt, totalPagesInt, siblingCount, totalPageNumbers);
 
     let dotCount = 0;

--- a/scripts/ansible/templates/archive_config.sql.j2
+++ b/scripts/ansible/templates/archive_config.sql.j2
@@ -23,7 +23,7 @@ INSERT IGNORE INTO `archive_configs`
    `archivist`, `collection_name`, `host`)
   VALUES
   (1, "{{ sitekey }}", "{{ name }}", "Testing", "OD STORY NOTE", "OD BOOKMARK NOTE", 0, 0,
-   "testy", "opendoorstestcollection", "test");
+   "opendoors_staging", "opendoorstestcollection", "test");
 
 --
 -- Table structure for table `audits`


### PR DESCRIPTION
The reported issue was caused by the values of leftItemCount and rightItemCount being different from totalPageNumbers NumberPagination component. When the number of pages for a letter = 9, leftItemCount and rightItemCount = 9 but totalPageNumbers = 8. On the live site this broke pages 4 and 5, but on the local site, pages 4 and 5 had a duplicate 9 listed. Removing leftItemCount and rightItemCount and using totalPageNumbers for all calculations resolved the issue.

Also added to this PR: changing the default archivist value on archive_configs from testy to opendoors_staging